### PR TITLE
Add 10s delay before prices pull

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,20 +27,23 @@ function Hb_Nordpool(log, config) {
    this._minHourPrice = 0;
    this._day_prices = [];
    
-
-   
-
    const hourlyJob = schedule('0 1-23  * * * * ', () => {
-      this.getCurrentPrice()
-
+      // delay 10s because homebridge systems clock may be out of sync 
+      // and pull previous hour data
+      setTimeout(() => {
+         this.getCurrentPrice();
+      }, 10000);
    });
    
    const dailyJob = schedule('0 0 * * *', () => {
       this.getDailyPrices(Date.now()).then(() => {
-         this.getCurrentPrice();
+         // delay 10s because homebridge systems clock may be out of sync 
+         // and pull previous hour data
+         setTimeout(() => {
+            this.getCurrentPrice();
+         }, 10000);
       });
    });
-
 
 }
 
@@ -88,7 +91,6 @@ Hb_Nordpool.prototype = {
       }
       
       const currentHour = new Date().getHours()
-
 
       if (currentHour == this._minHourPrice && this.occupancyServiceLow && this.occupancyServiceHigh) {
          this.occupancyServiceLow.getCharacteristic(Characteristic.OccupancyDetected).updateValue(Characteristic.OccupancyDetected.OCCUPANCY_NOT_DETECTED);


### PR DESCRIPTION
I was troubleshooting my own issues that prices through this extension were pulling previous hour data. It made me nuts until I figured my raspberry clock was simply 2 seconds out of sync.  This should fix similar problems for everyone.